### PR TITLE
Remove arbitrary server update cron job

### DIFF
--- a/entrypoint-user.sh
+++ b/entrypoint-user.sh
@@ -91,12 +91,6 @@ else
   ./"${GAMESERVER}" sponsor
 fi
 
-echo -e ""
-echo -e "Starting Update Checks"
-echo -e "================================="
-echo -e "*/${UPDATE_CHECK} * * * * /app/${GAMESERVER} update > /dev/null 2>&1" | crontab -
-echo -e "update will check every ${UPDATE_CHECK} minutes"
-
 # Update or validate game server
 if [ -z "${install}" ]; then
   echo -e ""

--- a/entrypoint-user.sh
+++ b/entrypoint-user.sh
@@ -91,6 +91,18 @@ else
   ./"${GAMESERVER}" sponsor
 fi
 
+if [ -n "${UPDATE_CHECK}" ] && [ "${UPDATE_CHECK}" != "0" ]; then
+  echo -e ""
+  echo -e "Starting Update Checks"
+  echo -e "================================="
+  echo -e "*/${UPDATE_CHECK} * * * * /app/${GAMESERVER} update > /dev/null 2>&1" | crontab -
+  echo -e "update will check every ${UPDATE_CHECK} minutes"
+else
+  echo -e ""
+  echo -e "Update checks are disabled"
+  echo -e "================================="
+fi
+
 # Update or validate game server
 if [ -z "${install}" ]; then
   echo -e ""


### PR DESCRIPTION
See [this issue](https://github.com/GameServerManagers/LinuxGSM/issues/4745) for context for this change.

**To summarise:** It seems that only the docker versions of the servers ship with this an update cron job preconfigured. This PR brings the docker version in line with the expected behaviour of the default usage of LGSM following the docs.