### PR TITLE
feat: add environment variable check to the update command so the user can enable/disable it using a new env variable

### DIFF
--- a/entrypoint-user.sh
+++ b/entrypoint-user.sh
@@ -110,7 +110,8 @@ if [ -z "${install}" ]; then
     echo -e "Validating ${GAMESERVER}"
     echo -e "================================="
     ./"${GAMESERVER}" validate
-  else
+  fi
+  if [ "${UPDATE_ON_START,,}" = "true" ]; then
     echo -e "Checking for Update ${GAMESERVER}"
     echo -e "================================="
     ./"${GAMESERVER}" update


### PR DESCRIPTION
Adds a check for a new environment variable that can be set during container creation, that enables the user to disable server update on container start.
Also made it so that the user can set validate and auto update on container start at the same time.

Fixes #91 