### PR TITLE
Container user linuxgsm crontab can be saved optionally

### DIFF
--- a/Dockerfile.ubuntu-2004
+++ b/Dockerfile.ubuntu-2004
@@ -29,6 +29,7 @@ ENV UPDATE_CHECK=60
 ENV USER=linuxgsm
 ENV UID=1000
 ENV GID=1000
+ENV LGSM_SAVE_CRONTAB=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile.ubuntu-2204
+++ b/Dockerfile.ubuntu-2204
@@ -29,6 +29,7 @@ ENV UPDATE_CHECK=60
 ENV USER=linuxgsm
 ENV UID=1000
 ENV GID=1000
+ENV LGSM_SAVE_CRONTAB=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile.ubuntu-2404
+++ b/Dockerfile.ubuntu-2404
@@ -29,6 +29,7 @@ ENV UPDATE_CHECK=60
 ENV USER=linuxgsm
 ENV UID=1000
 ENV GID=1000
+ENV LGSM_SAVE_CRONTAB=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/entrypoint-user.sh
+++ b/entrypoint-user.sh
@@ -91,7 +91,12 @@ else
   ./"${GAMESERVER}" sponsor
 fi
 
-if [ -n "${UPDATE_CHECK}" ] && [ "${UPDATE_CHECK}" != "0" ]; then
+if ( "${LGSM_SAVE_CRONTAB}" ) && [ -e "${LGSM_CRONTAB_SAVEPOINT}" ] ; then
+  echo -e ""
+  echo -e "Found saved crontab, restoring"
+  echo -e "================================="
+  cat "${LGSM_CRONTAB_SAVEPOINT}" | crontab - || echo -e "Crontab is invalid, NOT restored!"
+elif [ -n "${UPDATE_CHECK}" ] && [ "${UPDATE_CHECK}" != "0" ]; then
   echo -e ""
   echo -e "Starting Update Checks"
   echo -e "================================="

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 exit_handler() {
   # Execute the shutdown commands
+  if ( ${LGSM_SAVE_CRONTAB} ) ; then
+      echo -e "Saving user ${USER} crontab"
+      crontab -u "${USER}" -l > "${LGSM_CRONTAB_SAVEPOINT}"
+  fi
   echo -e "Stopping ${GAMESERVER}"
   exec gosu "${USER}" ./"${GAMESERVER}" stop
   exitcode=$?
@@ -62,6 +66,7 @@ chown -R "${USER}":"${USER}" /data
 echo -e "updating permissions for /app"
 chown -R "${USER}":"${USER}" /app
 export HOME=/data
+export LGSM_CRONTAB_SAVEPOINT="${HOME}"/saved-crontab
 
 echo -e ""
 echo -e "Switch to user ${USER}"


### PR DESCRIPTION
This should be transparent to users and requires no intervention if they do not wish to use a custom crontab. Current behavior is retained.

To actually use the custom crontab, the user needs to set LGSM_SAVE_CRONTAB to true. If set to false, the container will function exactly as it functions now. This variable needs to be documented in the downstream (docker image) repository.